### PR TITLE
Only run on initial webpack server startup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import preProcessPattern from './preProcessPattern';
 import processPattern from './processPattern';
 import writeManifest from './writeManifest';
 
+let hasRun = false;
+
 function CopyWebpackPlugin(patterns = [], options = {}) {
     if (!Array.isArray(patterns)) {
         throw new Error('[copy-webpack-plugin] patterns must be an array');
@@ -50,6 +52,11 @@ function CopyWebpackPlugin(patterns = [], options = {}) {
         const written = {};
 
         compiler.plugin('emit', (compilation, cb) => {
+            if (compiler.options.watch && hasRun) {
+                cb();
+                return
+            }
+            hasRun = true;
             debug('starting emit');
             const callback = () => {
                 debug('finishing emit');


### PR DESCRIPTION
A little bit of a hack, but so is using the copy files plugin. Maybe a more elegant solution will come in the future but this is more helpful for dev environments for the time being.

Both the webpack and django server need to be restarted when new assets are added but I think that is OK. 